### PR TITLE
Take into account that [rewrite in *] got more powerful

### DIFF
--- a/src/Parsers/ContextFreeGrammar/Fix/FixRelated.v
+++ b/src/Parsers/ContextFreeGrammar/Fix/FixRelated.v
@@ -74,7 +74,8 @@ Section grammar_fixedpoint.
     Proof.
       pose proof (related_aggregate_state_max initial_nonterminals_data HRbot) as H.
       unfold aggregate_state_relation in *.
-      rewrite PositiveMapExtensions.lift_relation_hetero_iff in *.
+      rewrite PositiveMapExtensions.lift_relation_hetero_iff in *. (* more powerful in econstr than it was in trunk; I think the econstr behavior is correct, but it should be marked as an explicit incompatibility *)
+      rewrite <- ?PositiveMapExtensions.lift_relation_hetero_iff in H.
       (*pose proof (@find_pre_Fix_grammar _ gdata0 G) as H0.
       pose proof (@find_pre_Fix_grammar _ gdata1 G) as H1.
       pose proof (fun nt => transitivity (symmetry (H0 nt)) (H1 nt)) as H01; clear H0 H1.


### PR DESCRIPTION
This makes fiat-parsers build with econstr